### PR TITLE
Update AutotaskAPI.psm1

### DIFF
--- a/AutotaskAPI.psm1
+++ b/AutotaskAPI.psm1
@@ -491,7 +491,7 @@ function New-AutotaskBody {
                     }
                 }
             }
-            $Names = if ($UDF) { $ObjectTemplate.name + "UserDefinedFields" } else { $ObjectTemplate.name }
+            $Names = if ($UDFs) { $ObjectTemplate.name + "UserDefinedFields" } else { $ObjectTemplate.name }
             return $ReturnedDef | select-object $Names
 
         }


### PR DESCRIPTION
When checking whether to add custom udfs to a body template, the script references $udf instead of $udfs. As $udf is never defined, the test always returns false and custom udfs are never added to a body template.