### PR TITLE
Set-AutotaskAPIResource Upgrades / Fixes

### DIFF
--- a/AutoTaskAPI.psd1
+++ b/AutoTaskAPI.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\AutoTaskAPI.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.1.1'
+    ModuleVersion = '1.2.1'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Public/Set-AutotaskAPIResource.ps1
+++ b/Public/Set-AutotaskAPIResource.ps1
@@ -15,10 +15,11 @@
 
     Get-AutotaskAPIResource -Resource Companies -SimpleSearch 'Isactive eq true' | ForEach-Object {$_.Webaddress = "www.google.com"; $_} | Set-AutotaskAPIResource -Resource companies
     A one-liner to change all companies webaddresses to "google.com".
-    
+
 .INPUTS
     -Resource: Which resource to find. Tab completion is available.
     -ID: ID of the resource you want to update. Can be passed as a property on the pipeline.
+    -ParentID: For use with 'Child' endpoints, the ID of the parent you are updating.
     -Body: A PS object containing all of the parameters you want to update. Can be passed by pipeline.
     
 .OUTPUTS
@@ -29,7 +30,7 @@
 function Set-AutotaskAPIResource {
     [CmdletBinding()]
     Param(
-        [Parameter(ParameterSetName = 'ParentID', Mandatory = $false)]
+        [Parameter(ParameterSetName = 'ParentID', Mandatory = $false)][String]$ParentId,
         [Parameter(ValueFromPipelineByPropertyName = $true)]$ID,
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]$body
     )
@@ -45,6 +46,13 @@ function Set-AutotaskAPIResource {
         $headers = $Script:AutotaskAuthHeader   
         $ResourceURL = (($Script:Queries | Where-Object { $_.'Patch' -eq $Resource }).Name | Select-Object -first 1) -replace '/query', '' | Select-Object -first 1
 
+        if ($resource -like "*child*" ) {
+            if ( !$ParentId ) {
+                Write-Warning "You must specify a parentId when settings a child resource" 
+                break 
+            }
+            $ResourceURL = $resourceURL -replace '{parentId}', $ParentId
+        }
     }
     
     process {

--- a/Public/Set-AutotaskAPIResource.ps1
+++ b/Public/Set-AutotaskAPIResource.ps1
@@ -45,14 +45,15 @@ function Set-AutotaskAPIResource {
         $headers = $Script:AutotaskAuthHeader   
         $ResourceURL = (($Script:Queries | Where-Object { $_.'Patch' -eq $Resource }).Name | Select-Object -first 1) -replace '/query', '' | Select-Object -first 1
 
+    }
+    
+    process {
         $MyBody = New-Object -TypeName PSObject
         if ($ID) {
             $MyBody | Add-Member -NotePropertyMembers @{id=$ID}
         }
         $PSBoundParameters.body.PSObject.properties | Where-Object {$null -ne $_.Value} | ForEach-Object {Add-Member -InputObject $MyBody -NotePropertyMembers @{$_.Name=$_.Value}}
-    }
-    
-    process {
+
         try {
             # Iterating through the property names above produces an array of n MyBody objects, all the same,
             # where n is the number of non-null properties.  Grab the first one.

--- a/Public/Set-AutotaskAPIResource.ps1
+++ b/Public/Set-AutotaskAPIResource.ps1
@@ -5,15 +5,22 @@
 .DESCRIPTION
  Sets a resource in the API to the supplied object. Uses the Patch method. Each item in the object will be overwritten at the API side. Null values will overwrite with null values.
 .EXAMPLE
-    PS C:\>  Get-AutotaskAPIResource -resource Companies -ID 1234
-    Finds the company with 1234 in the Autotask REST API.
+    PS C:\>  Set-AutotaskAPIResource -resource Companies -ID 1234 -Body $body
+    Updates the company with ID 1234 in the Autotask REST API, changing any parameters in $body.
 
-    PS C:\>  Get-AutotaskAPIResource -resource Companies -SearchQuery={filter='active -eq true'}
-    Finds all companies which are active.
+    PS C:\>  $TicketList = Get-AutotaskAPIResource -Resource Tickets -SimpleSearch "title eq Nope!"
+    PS C:\>  $ticketlist | ForEach-Object { $_.status = "12" }
+    PS C:\>  $ticketlist | Set-AutotaskAPIResource -Resource Tickets
+    Closes all tickets with the subject "Nope!".
+
+    Get-AutotaskAPIResource -Resource Companies -SimpleSearch 'Isactive eq true' | ForEach-Object {$_.Webaddress = "www.google.com"; $_} | Set-AutotaskAPIResource -Resource companies
+    A one-liner to change all companies webaddresses to "google.com".
+    
 .INPUTS
     -Resource: Which resource to find. Tab completion is available.
-    -ID: ID of the resource you want to retrieve
-    -SearchQuery: JSON Search filter.
+    -ID: ID of the resource you want to update. Can be passed as a property on the pipeline.
+    -Body: A PS object containing all of the parameters you want to update. Can be passed by pipeline.
+    
 .OUTPUTS
     none
 .NOTES


### PR DESCRIPTION
This set of commits primarily does 2 things:
1. It adds a new `ParentID` argument for child endpoints. I have re-used the code for this from New-AutotaskAPIResource as much as possible so that this is done in a similar way.
2. Fixes the passing of the $ID parameter by the pipeline (#33). In my testing I found that the below code would not work properly in the `begin` block so I moved it into the `process` block which fixed the issue.
```
$MyBody = New-Object -TypeName PSObject
if ($ID) {
    $MyBody | Add-Member -NotePropertyMembers @{id=$ID}
}
```

Additionally, the examples were a copy from Get-AutotaskAPIResource and these had never been updated, so I have fixed these examples and other comments.