### PR TITLE
Add /V1.0/InvoicePDF to Swagger update Get-AutotaskAPIResource to allow PDF invoice downloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+PSGetModuleInfo.xml

--- a/AutoTaskAPI.psd1
+++ b/AutoTaskAPI.psd1
@@ -12,7 +12,7 @@
     RootModule        = '.\AutoTaskAPI.psm1'
     
     # Version number of this module.
-    ModuleVersion     = '1.2.2'
+    ModuleVersion     = '1.2.3'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Public/Set-AutotaskAPIResource.ps1
+++ b/Public/Set-AutotaskAPIResource.ps1
@@ -60,7 +60,7 @@ function Set-AutotaskAPIResource {
         if ($ID) {
             $MyBody | Add-Member -NotePropertyMembers @{id=$ID}
         }
-        $PSBoundParameters.body.PSObject.properties | Where-Object {$null -ne $_.Value} | ForEach-Object {Add-Member -InputObject $MyBody -NotePropertyMembers @{$_.Name=$_.Value}}
+        $PSBoundParameters.body.PSObject.properties | Where-Object {$null -ne $_.Value} | ForEach-Object {Add-Member -Force -InputObject $MyBody -NotePropertyMembers @{$_.Name=$_.Value}}
 
         try {
             # Iterating through the property names above produces an array of n MyBody objects, all the same,

--- a/v1.json
+++ b/v1.json
@@ -65879,6 +65879,72 @@
         }
       }
     },
+    "/V1.0/InvoicePDF": {
+      "get": {
+        "tags": [
+          "InvoicePDF"
+        ],
+        "operationId": "InvoicePDF_QueryItem",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "ApiIntegrationCode",
+            "in": "header",
+            "description": "API Integration Code",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "UserName",
+            "in": "header",
+            "description": "User Name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "Secret",
+            "in": "header",
+            "description": "Secret",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ImpersonationResourceId",
+            "in": "header",
+            "description": "Impersonation Resource Key",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/InvoicePDFModel"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
     "/V1.0/Invoices/query/count": {
       "get": {
         "tags": [
@@ -144130,6 +144196,29 @@
           "items": {
             "$ref": "#/definitions/UserDefinedField"
           }
+        }
+      }
+    },
+    "InvoicePDFModel": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        },
+        "fileSize": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "data": {
+          "format": "byte",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
Edits to allow request of Invoice PDF file format from Autotask, which used to be documented in the Autotask REST API docs and seems to have been removed, but still works--then it was re-added to the docs at some point because I can now find it again in the docs at https://www.autotask.net/help/developerhelp/Content/APIs/REST/Entities/InvoicesEntity.htm?Highlight=InvoicePDF

Was not listed in Swagger file, and required some changes to Get-AutotaskAPIResource to add functionality. Bumped version to 1.2.3 to compile and run locally where this has been used for over a year successfully. PSGetModuleInfo.xml file also exists locally with new version number but has been added to .gitignore to avoid pushing with commit.

First-time contribution attempt, I'm sure I got something wrong...but would also like to see this support in the public module.