### PR TITLE
Pin zone lookup to V1.0 so Add-AutotaskAPIAuth stops 404ing

### DIFF
--- a/Public/Add-AutotaskAPIAuth.ps1
+++ b/Public/Add-AutotaskAPIAuth.ps1
@@ -29,7 +29,10 @@ function Add-AutotaskAPIAuth (
     }
     write-host "Retrieving webservices URI based on username" -ForegroundColor Green
     try {
-        $Version = (Invoke-RestMethod -Uri "https://webservices2.autotask.net/atservicesrest/versioninformation").apiversions | select-object -last 1
+        # The bundled v1.json only describes V1.0 paths, so the zone lookup must use V1.0.
+        # Autotask now advertises "V2.0" in /versioninformation, and V2.0 has no zoneInformation
+        # route -- taking the last entry made this call 404 and left AutotaskBaseURI unset.
+        $Version = "V1.0"
         $AutotaskBaseURI = Invoke-RestMethod -Uri "https://webservices2.autotask.net/atservicesrest/$($Version)/zoneInformation?user=$($Script:AutotaskAuthHeader.UserName)"
         write-host "Setting AutotaskBaseURI to $($AutotaskBaseURI.url) using version $Version" -ForegroundColor green
         Add-AutotaskBaseURI -BaseURI $AutotaskBaseURI.url.Trim('/')


### PR DESCRIPTION
### The break

Autotask now advertises a second API version. `/atservicesrest/versioninformation` returns:

```json
{ "apiVersions": ["V1.0", "V2.0"] }
```

`Add-AutotaskAPIAuth` takes the **last** entry, so it started requesting `V2.0/zoneInformation` — which is not a route:

| version | `zoneInformation` status |
| --- | --- |
| V1.0 | 500 (route exists; bogus user) |
| V2.0 | **404 (no route)** |

This endpoint is unauthenticated and hardcoded to `webservices2` for everyone, so it is not tenant-specific — every user relying on auto-detection is affected, on any zone.

### Why it presents as an unrelated error

The 404 is swallowed into the existing `catch`, so auth appears to half-succeed: `$Script:AutotaskAuthHeader` **is** set (it happens before the `try`), but `$Script:AutotaskBaseURI` is not. Since `Add-AutotaskBaseURI` is what populates `$Script:GetParameter` and friends, the dynamic `-Resource` parameter is never built — and the next call dies with something that looks nothing like an auth problem:

```
Get-AutotaskAPIResource: A parameter cannot be found that matches parameter name 'Resource'.
```

That red `Could not Retrieve baseuri` line is easy to read as a stale warning, which sends people hunting for a bad email address or credential.

### The fix

The version negotiation was never actionable: all 1420 paths in the bundled `v1.json` are `/V1.0/...`, so the module can only speak V1.0 regardless of what the endpoint advertises. Pinning the lookup makes the request match the module's actual capability.

```diff
-$Version = (Invoke-RestMethod -Uri ".../versioninformation").apiversions | select-object -last 1
+$Version = "V1.0"
```

### Verification

Against a live tenant, with the patched module imported directly from this branch:

```
Retrieving webservices URI based on username
Setting AutotaskBaseURI to https://webservices3.autotask.net/ATServicesRest/ using version V1.0
Setting API resource parameters. This may take a moment.
RESULT: -Resource parameter worked; company name = Servant 42
```

No warning, zone resolves, `Get-AutotaskAPIResource -Resource Companies` returns data.
