### PR TITLE
Join multi-word SimpleSearch values so the filter JSON stays valid

### DIFF
--- a/Public/Get-AutotaskAPIResource.ps1
+++ b/Public/Get-AutotaskAPIResource.ps1
@@ -63,7 +63,9 @@ function Get-AutotaskAPIResource {
                 filter = @(@{
                         field = $SearchOps[0]
                         op    = $SearchOps[1]
-                        value = $SearchOps | Select-Object -Skip 2
+                        # Join back to a scalar: a multi-word value (a date, a company name)
+                        # would otherwise serialize as a JSON array, which the API rejects.
+                        value = ($SearchOps | Select-Object -Skip 2) -join ' '
                     })
             } -Compress
         }


### PR DESCRIPTION
Independent of #76 — different file, different bug, no overlap.

### Symptom

Every `-SimpleSearch` whose value contains a space emits a warning:

```
WARNING: Resulting JSON is truncated as serialization has exceeded the set depth of 2.
```

```powershell
Get-AutotaskAPIResource -Resource Invoices -SimpleSearch "invoiceDateTime eq 9/1/2026 12:00:00 AM"
```

A single-token value (`invoiceNumber eq 29777115`) does not warn.

### Cause

`-SimpleSearch` splits on spaces and assigns the remainder to `value`:

```powershell
value = $SearchOps | Select-Object -Skip 2
```

That returns an **array** for any multi-word value, and the array sits one level below the default `ConvertTo-Json` depth of 2. (The module's other two `ConvertTo-Json` calls, in `Set-` and `New-AutotaskAPIResource`, both pass `-Depth 10`; this one doesn't.)

### Why the obvious fix is wrong

The searches work today *only because* the truncation collapses the array into its space-joined string — which is exactly the scalar the API wants. The bug and the workaround are the same line. Adding `-Depth 10` here, to match the rest of the module, would start sending:

| | JSON emitted |
| --- | --- |
| current (depth 2) | `{"filter":[{"field":"invoiceDateTime","op":"eq","value":"9/1/2026 12:00:00 AM"}]}` |
| `-Depth 10` | `{"filter":[{"field":"invoiceDateTime","op":"eq","value":["9/1/2026","12:00:00","AM"]}]}` |

…and break every multi-word SimpleSearch. Worth flagging in case anyone reaches for that first.

### The fix

Make the value a scalar before serializing, so the intended string is produced deliberately rather than as a side effect of hitting the depth limit:

```diff
-value = $SearchOps | Select-Object -Skip 2
+value = ($SearchOps | Select-Object -Skip 2) -join ' '
```

### Verification

JSON is byte-identical to what ships today across three search shapes:

| search | before | after |
| --- | --- | --- |
| `invoiceDateTime eq 9/1/2026 12:00:00 AM` | `"value":"9/1/2026 12:00:00 AM"` | same |
| `invoiceNumber eq 29777115` | `"value":"29777115"` | same |
| `companyName beginswith A` | `"value":"A"` | same |

Against a live tenant, the date filter returns the same 87 invoices with the same first `invoiceNumber` as before, and no warning.
